### PR TITLE
Remove `null` field opt, it does not exist

### DIFF
--- a/lib/events/user_data.ex
+++ b/lib/events/user_data.ex
@@ -39,8 +39,8 @@ defmodule FacebookConversions.Events.UserData do
     field(:client_ip_address, :string)
     field(:client_user_agent, :string)
     field(:external_id, {:array, :string})
-    field(:fbc, :string, null: true)
-    field(:fbp, :string, null: true)
+    field(:fbc, :string)
+    field(:fbp, :string)
   end
 
   @spec changeset(%__MODULE__{}, map()) :: __MODULE__.t()


### PR DESCRIPTION
`null` option does not exist, latest Ecto version raises an error for it.

See https://hexdocs.pm/ecto/3.7.2/Ecto.Schema.html#field/3 for more info
